### PR TITLE
Fix even-odd rule having no effect in dx11 mode

### DIFF
--- a/src/core/d3d11/scene_builder.cpp
+++ b/src/core/d3d11/scene_builder.cpp
@@ -47,6 +47,8 @@ std::shared_ptr<BuiltDrawPath> prepare_draw_path_for_gpu_binning(Scene &scene,
     TilingPathInfo path_info{};
     path_info.type = TilingPathInfo::Type::Draw;
     path_info.info.paint_id = paint_id;
+    path_info.info.blend_mode = draw_path.blend_mode;
+    path_info.info.fill_rule = draw_path.fill_rule;
 
     auto built_path =
         BuiltPath(draw_path_id, path_bounds, effective_view_box, draw_path.fill_rule, draw_path.clip_path, path_info);


### PR DESCRIPTION
Fix regression caused by 145da2a1b09892ef65ab87b4e35ce12f0d54f4c6.