### PR TITLE
Allow dynamic render level selection

### DIFF
--- a/demo/common/app.cpp
+++ b/demo/common/app.cpp
@@ -13,7 +13,7 @@ App::App(const std::shared_ptr<Device> &_device,
     queue = _queue;
 
     // Set up a canvas.
-    canvas = std::make_shared<Canvas>(device, queue);
+    canvas = std::make_shared<Canvas>(device, queue, RenderLevel::Dx9);
 
     // TEST: Clip path.
     if (false) {
@@ -81,16 +81,18 @@ App::App(const std::shared_ptr<Device> &_device,
         canvas->draw_render_target(render_target_id, {{}, render_target_size.to_f32()});
     }
 
+    scene_0 = canvas->get_scene();
+
     // TEST: Append SVG scene.
     if (true) {
         SvgScene svg_scene;
         svg_scene.load_from_string(std::string(svg_input.begin(), svg_input.end()), *canvas);
 
         // TEST: Replace scene.
-        //         canvas->set_scene(svg_scene.get_scene());
+        scene_1 = svg_scene.get_scene();
 
         // TEST: Append scene.
-        canvas->get_scene()->append_scene(*svg_scene.get_scene(), Transform2::from_scale({1.0, 1.0}));
+        //        canvas->get_scene()->append_scene(*scene_1, Transform2::from_scale({1.0, 1.0}));
     }
 
     // Timer.
@@ -121,7 +123,11 @@ void App::update() {
     }
     // ----------------------------------------
 
-    canvas->draw();
+    canvas->set_scene(scene_0);
+    canvas->draw(true);
+
+    canvas->set_scene(scene_1);
+    canvas->draw(false);
 }
 
 void App::cleanup() {

--- a/demo/common/app.h
+++ b/demo/common/app.h
@@ -21,6 +21,8 @@ public:
 
     std::shared_ptr<Canvas> canvas;
 
+    std::shared_ptr<Scene> scene_0, scene_1;
+
     std::shared_ptr<Device> device;
     std::shared_ptr<Queue> queue;
 

--- a/src/common/global_macros.h
+++ b/src/common/global_macros.h
@@ -1,10 +1,15 @@
 #ifndef PATHFINDER_GLOBAL_MACROS_H
 #define PATHFINDER_GLOBAL_MACROS_H
 
-// Choose between D3D9 and D3D11.
-//#define PATHFINDER_USE_D3D11
+// Enable Dx11 render level.
+#define PATHFINDER_ENABLE_D3D11
 
-// Enable this if GLES3.0 support is needed.
+// Dx11 level is not available in Web.
+#if defined(__EMSCRIPTEN__)
+    #undef PATHFINDER_ENABLE_D3D11
+#endif
+
+// Enable this if ES3.0 support is needed.
 // #define PATHFINDER_MINIMUM_SHADER_VERSION_SUPPORT
 
 // WebGL only supports ES3.0 shaders.

--- a/src/core/canvas.h
+++ b/src/core/canvas.h
@@ -50,7 +50,9 @@ enum class PathOp {
 /// Normally, we only need one canvas to render multiple scenes.
 class Canvas {
 public:
-    explicit Canvas(const std::shared_ptr<Device> &_device, const std::shared_ptr<Queue> &_queue);
+    explicit Canvas(const std::shared_ptr<Device> &_device,
+                    const std::shared_ptr<Queue> &_queue,
+                    RenderLevel _render_level);
 
     /// Clears the current canvas.
     /// You shouldn't call this per frame.
@@ -173,7 +175,7 @@ public:
 
     void restore_state();
 
-    void draw();
+    void draw(bool clear_dst_texture);
 
     // Extensions
 
@@ -189,17 +191,22 @@ private:
     void push_path(Outline &outline, PathOp path_op, FillRule fill_rule);
 
 private:
-    // Brush state management.
+    /// Brush state management.
     BrushState current_state;
     std::vector<BrushState> saved_states;
 
     std::shared_ptr<Scene> scene;
 
-    /// Rendering API related.
-    std::shared_ptr<Device> device;
+    /// Scene builder.
+    std::shared_ptr<SceneBuilder> scene_builder;
 
     /// Scene renderer.
     std::shared_ptr<Renderer> renderer;
+
+    /// Rendering API related.
+    std::shared_ptr<Device> device;
+
+    RenderLevel render_level;
 };
 
 } // namespace Pathfinder

--- a/src/core/d3d11/gpu_data.cpp
+++ b/src/core/d3d11/gpu_data.cpp
@@ -1,6 +1,6 @@
 #include "gpu_data.h"
 
-#ifdef PATHFINDER_USE_D3D11
+#ifdef PATHFINDER_ENABLE_D3D11
 
 namespace Pathfinder {
 

--- a/src/core/d3d11/gpu_data.h
+++ b/src/core/d3d11/gpu_data.h
@@ -10,7 +10,7 @@
 #include "../paint/paint.h"
 #include "../scene.h"
 
-#ifdef PATHFINDER_USE_D3D11
+#ifdef PATHFINDER_ENABLE_D3D11
 
 //! Data that will be sent directly to GPU.
 

--- a/src/core/d3d11/renderer.cpp
+++ b/src/core/d3d11/renderer.cpp
@@ -11,7 +11,7 @@
 #include "../data/data.h"
 #include "gpu_data.h"
 
-#ifdef PATHFINDER_USE_D3D11
+#ifdef PATHFINDER_ENABLE_D3D11
     #ifdef PATHFINDER_USE_VULKAN
         #include "../../shaders/generated/bin_comp_spv.h"
         #include "../../shaders/generated/bound_comp_spv.h"
@@ -245,7 +245,9 @@ void RendererD3D11::set_up_pipelines() {
     tile_pipeline = device->create_compute_pipeline(tile_source, tile_descriptor_set, "Tile pipeline");    // 7
 }
 
-void RendererD3D11::draw(const std::shared_ptr<SceneBuilder> &_scene_builder) {
+void RendererD3D11::draw(const std::shared_ptr<SceneBuilder> &_scene_builder, bool _clear_dst_texture) {
+    clear_dest_texture = _clear_dst_texture;
+
     auto *scene_builder = static_cast<SceneBuilderD3D11 *>(_scene_builder.get());
 
     if (scene_builder->built_segments.draw_segments.points.empty()) {
@@ -256,7 +258,6 @@ void RendererD3D11::draw(const std::shared_ptr<SceneBuilder> &_scene_builder) {
     upload_scene(scene_builder->built_segments.draw_segments, scene_builder->built_segments.clip_segments);
 
     alpha_tile_count = 0;
-    clear_dest_texture = true;
 
     // Prepare clip tiles.
     {

--- a/src/core/d3d11/renderer.h
+++ b/src/core/d3d11/renderer.h
@@ -9,7 +9,7 @@
 #include "gpu_data.h"
 #include "scene_builder.h"
 
-#ifdef PATHFINDER_USE_D3D11
+#ifdef PATHFINDER_ENABLE_D3D11
 
 namespace Pathfinder {
 
@@ -91,7 +91,7 @@ public:
 
     void set_up_pipelines() override;
 
-    void draw(const std::shared_ptr<SceneBuilder> &scene_builder) override;
+    void draw(const std::shared_ptr<SceneBuilder> &scene_builder, bool _clear_dst_texture) override;
 
     std::shared_ptr<Texture> get_dest_texture() override;
 

--- a/src/core/d3d11/scene_builder.cpp
+++ b/src/core/d3d11/scene_builder.cpp
@@ -5,7 +5,7 @@
 #include "../data/built_path.h"
 #include "gpu_data.h"
 
-#ifdef PATHFINDER_USE_D3D11
+#ifdef PATHFINDER_ENABLE_D3D11
 
 namespace Pathfinder {
 
@@ -194,7 +194,9 @@ std::vector<DrawTileBatchD3D11> build_tile_batches_for_draw_path_display_item(
     return flushed_draw_tile_batches;
 }
 
-void SceneBuilderD3D11::build(Renderer *renderer) {
+void SceneBuilderD3D11::build(Scene *_scene, Renderer *renderer) {
+    scene = _scene;
+
     built_segments = BuiltSegments::from_scene(*scene);
 
     // Build paint data.

--- a/src/core/d3d11/scene_builder.h
+++ b/src/core/d3d11/scene_builder.h
@@ -6,7 +6,7 @@
 #include "../scene_builder.h"
 #include "gpu_data.h"
 
-#ifdef PATHFINDER_USE_D3D11
+#ifdef PATHFINDER_ENABLE_D3D11
 
 namespace Pathfinder {
 
@@ -46,7 +46,7 @@ struct ClipBatchesD3D11 {
 
 class SceneBuilderD3D11 : public SceneBuilder {
 public:
-    explicit SceneBuilderD3D11(Scene *_scene) : SceneBuilder(_scene) {}
+    explicit SceneBuilderD3D11() {}
 
     BuiltSegments built_segments;
 
@@ -55,7 +55,7 @@ public:
     // Will be sent to renderer to draw tiles.
     std::vector<DrawTileBatchD3D11> tile_batches;
 
-    void build(Renderer *renderer) override;
+    void build(Scene *_scene, Renderer *renderer) override;
 
 private:
     void finish_building(LastSceneInfo &last_scene,

--- a/src/core/d3d9/renderer.cpp
+++ b/src/core/d3d9/renderer.cpp
@@ -318,12 +318,14 @@ void RendererD3D9::create_tile_clip_combine_pipeline() {
                                                                 "Tile clip combine pipeline");
 }
 
-void RendererD3D9::draw(const std::shared_ptr<SceneBuilder> &_scene_builder) {
+void RendererD3D9::draw(const std::shared_ptr<SceneBuilder> &_scene_builder, bool _clear_dst_texture) {
     auto *scene_builder = static_cast<SceneBuilderD3D9 *>(_scene_builder.get());
 
     // We are supposed to draw fills before the builder finishes building.
     // However, it seems not providing much performance boost.
     // So, we just leave it as it is for the sake of simplicity.
+
+    clear_dest_texture = _clear_dst_texture;
 
     alpha_tile_count = 0;
 
@@ -388,9 +390,6 @@ uint64_t RendererD3D9::upload_tiles(const std::vector<TileObjectPrimitive> &tile
 }
 
 void RendererD3D9::upload_and_draw_tiles(const std::vector<DrawTileBatchD3D9> &tile_batches) {
-    // Clear the destination framebuffer for the first time.
-    clear_dest_texture = true;
-
     // One draw call for one batch.
     for (const auto &batch : tile_batches) {
         uint32_t tile_count = batch.tiles.size();

--- a/src/core/d3d9/renderer.h
+++ b/src/core/d3d9/renderer.h
@@ -73,7 +73,7 @@ public:
     void set_up_pipelines() override;
 
     /// We need to call this for each scene.
-    void draw(const std::shared_ptr<SceneBuilder> &_scene_builder) override;
+    void draw(const std::shared_ptr<SceneBuilder> &_scene_builder, bool _clear_dst_texture) override;
 
     std::shared_ptr<Texture> get_dest_texture() override;
 

--- a/src/core/d3d9/scene_builder.cpp
+++ b/src/core/d3d9/scene_builder.cpp
@@ -93,7 +93,9 @@ std::vector<DrawTileBatchD3D9> build_tile_batches_for_draw_path_display_item(
     return flushed_draw_tile_batches;
 }
 
-void SceneBuilderD3D9::build(Renderer *renderer) {
+void SceneBuilderD3D9::build(Scene *_scene, Renderer *renderer) {
+    scene = _scene;
+
     // Build paint data.
     auto paint_metadata = scene->palette.build_paint_info(renderer);
 

--- a/src/core/d3d9/scene_builder.h
+++ b/src/core/d3d9/scene_builder.h
@@ -39,7 +39,7 @@ struct DrawPathBuildParams {
 /// Such data only changes when the scene becomes dirty and is rebuilt.
 class SceneBuilderD3D9 : public SceneBuilder {
 public:
-    explicit SceneBuilderD3D9(Scene *_scene) : SceneBuilder(_scene) {}
+    explicit SceneBuilderD3D9() {}
 
     // Data that will be sent to a renderer.
     // ------------------------------------------
@@ -57,7 +57,7 @@ public:
     std::array<std::atomic<size_t>, ALPHA_TILE_LEVEL_COUNT> next_alpha_tile_indices;
 
     /// Build everything we need for rendering.
-    void build(Renderer *renderer) override;
+    void build(Scene* _scene, Renderer *renderer) override;
 
 private:
     /// For parallel fill insertion.

--- a/src/core/renderer.cpp
+++ b/src/core/renderer.cpp
@@ -108,13 +108,8 @@ void Renderer::upload_texel_data(std::vector<ColorU> &texels, TextureLocation lo
     texture_page->must_preserve_contents = true;
 }
 
-void Renderer::start_rendering() {
+void Renderer::reset() {
     render_target_locations.clear();
-}
-
-void Renderer::begin_scene() {}
-
-void Renderer::end_scene() {
     allocator->purge_if_needed();
 }
 

--- a/src/core/renderer.h
+++ b/src/core/renderer.h
@@ -47,6 +47,11 @@ struct MaskStorage {
     uint32_t allocated_page_count = 0;
 };
 
+enum RenderLevel {
+    Dx9,
+    Dx11,
+};
+
 /// In most cases, we have only one renderer set up, while having
 /// multiple scenes prepared for rendering.
 /// All GPU operations happens in the renderer.
@@ -72,24 +77,13 @@ public:
 
     virtual void set_dest_texture(const std::shared_ptr<Texture> &new_texture) = 0;
 
-    void start_rendering();
-
-    virtual void draw(const std::shared_ptr<SceneBuilder> &_scene_builder) = 0;
+    virtual void draw(const std::shared_ptr<SceneBuilder> &_scene_builder, bool _clear_dst_texture) = 0;
 
     TextureLocation get_render_target_location(RenderTargetId render_target_id);
 
     RenderTarget get_render_target(RenderTargetId render_target_id);
 
-    /// Performs work necessary to begin rendering a scene.
-    ///
-    /// This must be called before `render_command()`.
-    void begin_scene();
-
-    /// Finishes rendering a scene.
-    ///
-    /// Note that, after calling this method, you might need to flush the output to the screen via
-    /// `swap_buffers()`, `present()`, or a similar method that your windowing library offers.
-    void end_scene();
+    void reset();
 
     std::shared_ptr<Sampler> get_or_create_sampler(TextureSamplingFlags sampling_flags);
 

--- a/src/core/scene.cpp
+++ b/src/core/scene.cpp
@@ -25,14 +25,7 @@ void SceneEpoch::next() {
     *this = successor();
 }
 
-Scene::Scene(uint32_t _id, RectF _view_box) : id(_id), view_box(_view_box), palette(Palette(_id)) {
-    // Create the scene builder.
-#ifndef PATHFINDER_USE_D3D11
-    scene_builder = std::make_shared<SceneBuilderD3D9>(this);
-#else
-    scene_builder = std::make_shared<SceneBuilderD3D11>(this);
-#endif
-}
+Scene::Scene(uint32_t _id, RectF _view_box) : id(_id), view_box(_view_box), palette(Palette(_id)) {}
 
 uint32_t Scene::push_paint(const Paint &paint) {
     auto paint_id = palette.push_paint(paint);
@@ -198,29 +191,6 @@ RectF Scene::get_bounds() {
 void Scene::set_bounds(const RectF &new_bounds) {
     bounds = new_bounds;
     epoch.next();
-}
-
-void Scene::build(std::shared_ptr<Renderer> &renderer) {
-    // No need to rebuild the scene if it hasn't changed.
-    // Comment this to do benchmark more precisely.
-    if (scene_builder && is_dirty) {
-        renderer->start_rendering();
-
-        scene_builder->build(renderer.get());
-
-        // Mark the scene as clean, so we don't need to rebuild it the next frame.
-        is_dirty = false;
-    }
-}
-
-void Scene::build_and_render(std::shared_ptr<Renderer> &renderer) {
-    renderer->begin_scene();
-
-    build(renderer);
-
-    renderer->draw(scene_builder);
-
-    renderer->end_scene();
 }
 
 } // namespace Pathfinder

--- a/src/core/scene.h
+++ b/src/core/scene.h
@@ -29,7 +29,7 @@ struct DisplayItem {
 
     RenderTargetId render_target_id{}; // For PushRenderTarget.
 
-    Range range;                       // For DrawPaths.
+    Range range; // For DrawPaths.
 };
 
 /// Used to control RenderTarget changing.
@@ -51,8 +51,6 @@ struct LastSceneInfo {
     std::vector<Range> draw_segment_ranges;
     std::vector<Range> clip_segment_ranges;
 };
-
-class SceneBuilder;
 
 /// The vector scene to be rendered.
 /// You can see scenes as an analogy of SVG images.
@@ -131,20 +129,11 @@ public:
 
     void set_bounds(const RectF &new_bounds);
 
-    /// Build the scene by SceneBuilder.
-    void build(std::shared_ptr<Renderer> &renderer);
-
-    /// A convenience method to build and render the scene.
-    void build_and_render(std::shared_ptr<Renderer> &renderer);
-
 private:
     RectF bounds;
 
     /// Scene-wide clipping control.
     RectF view_box;
-
-    /// Scene builder.
-    std::shared_ptr<SceneBuilder> scene_builder;
 };
 
 } // namespace Pathfinder

--- a/src/core/scene_builder.h
+++ b/src/core/scene_builder.h
@@ -17,10 +17,10 @@ class Renderer;
 // A builder doesn't involve GPU related code.
 class SceneBuilder {
 public:
-    explicit SceneBuilder(Scene* _scene) : scene(_scene) {}
+    explicit SceneBuilder() {}
 
     /// Build everything we need for rendering.
-    virtual void build(Renderer* renderer) = 0;
+    virtual void build(Scene* _scene, Renderer* renderer) = 0;
 
     Scene* get_scene() {
         return scene;

--- a/src/gpu/data.h
+++ b/src/gpu/data.h
@@ -7,7 +7,7 @@
     #ifdef PATHFINDER_USE_VULKAN
         #include "vulkan_wrapper.h"
     #else
-        #ifdef PATHFINDER_USE_D3D11
+        #ifdef PATHFINDER_ENABLE_D3D11
             #include <GLES3/gl31.h>
         #else
             #include <GLES3/gl3.h>

--- a/src/gpu/gl/buffer.cpp
+++ b/src/gpu/gl/buffer.cpp
@@ -29,7 +29,7 @@ BufferGl::BufferGl(const BufferDescriptor &_desc) : Buffer(_desc) {
             abort();
         } break;
         case BufferType::Storage: {
-    #ifdef PATHFINDER_USE_D3D11
+    #ifdef PATHFINDER_ENABLE_D3D11
             target = GL_SHADER_STORAGE_BUFFER;
     #endif
         } break;
@@ -60,7 +60,7 @@ void BufferGl::upload_via_mapping(size_t data_size, size_t offset, void *data) {
             Logger::error("Cannot handle index buffers yet!");
         } break;
         case BufferType::Storage: {
-    #ifdef PATHFINDER_USE_D3D11
+    #ifdef PATHFINDER_ENABLE_D3D11
             gl_buffer_type = GL_SHADER_STORAGE_BUFFER;
     #endif
         } break;
@@ -80,7 +80,7 @@ void BufferGl::download_via_mapping(size_t data_size, size_t offset, void *data)
         return;
     }
 
-    #ifdef PATHFINDER_USE_D3D11
+    #ifdef PATHFINDER_ENABLE_D3D11
     glBindBuffer(GL_SHADER_STORAGE_BUFFER, id);
         #ifdef __ANDROID__
     void *ptr = glMapBufferRange(GL_SHADER_STORAGE_BUFFER, offset, data_size, GL_MAP_READ_BIT);

--- a/src/gpu/gl/command_encoder.cpp
+++ b/src/gpu/gl/command_encoder.cpp
@@ -202,7 +202,7 @@ bool CommandEncoderGl::finish() {
                                             to_gl_sampler_filter(sampler_descriptor.mag_filter));
                             // --------------------------------------------------------------
                         } break;
-    #ifdef PATHFINDER_USE_D3D11
+    #ifdef PATHFINDER_ENABLE_D3D11
                         case DescriptorType::StorageBuffer: {
                             auto buffer_gl = static_cast<BufferGl *>(descriptor.buffer.get());
 
@@ -257,7 +257,7 @@ bool CommandEncoderGl::finish() {
                 compute_pipeline = args.pipeline;
             } break;
             case CommandType::Dispatch: {
-    #ifdef PATHFINDER_USE_D3D11
+    #ifdef PATHFINDER_ENABLE_D3D11
                 auto &args = cmd.args.dispatch;
 
                 // Max global (total) work group counts x:2147483647 y:65535 z:65535.

--- a/src/gpu/gl/program.cpp
+++ b/src/gpu/gl/program.cpp
@@ -104,7 +104,7 @@ ComputeProgram::ComputeProgram(const std::vector<char> &compute_code) : Program(
 }
 
 void ComputeProgram::compile(const char *compute_code) {
-    #ifdef PATHFINDER_USE_D3D11
+    #ifdef PATHFINDER_ENABLE_D3D11
     // Compile shaders.
     unsigned int compute = glCreateShader(GL_COMPUTE_SHADER);
     glShaderSource(compute, 1, &compute_code, nullptr);

--- a/src/gpu/gl/texture.cpp
+++ b/src/gpu/gl/texture.cpp
@@ -16,7 +16,7 @@ TextureGl::TextureGl(const TextureDescriptor& _desc) : Texture(_desc) {
 
     // Allocate space.
     // We need to use glTexStorage2D() in order to access the texture via image2D in compute shaders.
-    #ifdef PATHFINDER_USE_D3D11
+    #ifdef PATHFINDER_ENABLE_D3D11
     glTexStorage2D(GL_TEXTURE_2D, 1, to_gl_texture_format(_desc.format), _desc.size.x, _desc.size.y);
     #else
     // We can deduce the pixel data type by the texture format.

--- a/src/gpu/gl/window.cpp
+++ b/src/gpu/gl/window.cpp
@@ -30,7 +30,7 @@ void WindowGl::init() {
     // GLFW: initialize and configure.
     glfwInit();
 
-            #ifdef PATHFINDER_USE_D3D11
+            #ifdef PATHFINDER_ENABLE_D3D11
     glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 4);
             #else
     glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);


### PR DESCRIPTION
Major changes:

1. Allow dynamic render level selection (Dx9 & Dx11) when creating a `Canvas`.
2. Remove scene building caching.
3. Clarify `Canvas` drawing logic.